### PR TITLE
add Cache::TTLCache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :development do
   gem 'webmock'
   gem 'guard'
   gem 'guard-rspec'
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       tilt (~> 2.0)
     thor (0.20.0)
     tilt (2.0.8)
+    timecop (0.9.1)
     webmock (3.2.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -103,7 +104,8 @@ DEPENDENCIES
   rake
   rspec
   sinatra
+  timecop
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -1,0 +1,38 @@
+
+module Cache
+  # This class represents a very simple cache with TTL (time to live).
+  # Cached data (key and value) must has #hash and #eq?.
+  class TTLCache
+    Entry = Struct.new('Entry', :value, :ttl)
+
+    def initialize(timeout_sec: 300)
+      @entries = {}
+      @timeout_sec = timeout_sec
+    end
+
+    def with_cache(key)
+      now = Time.now
+      expire_old_entry(now)
+      if @entries.has_key?(key) && now <= @entries[key].ttl
+        return @entries[key].value
+      end
+      value = yield
+      @entries[key] = Entry.new(value, now + @timeout_sec)
+      value
+    end
+
+    def clear
+      @entries = {}
+      nil
+    end
+
+    private
+
+    # From the oldest entry, find expired entries and delete it
+    def expire_old_entry(now)
+      @entries.each_value.take_while {|e| e.ttl < now }.each {|e| @entries.delete(e) }
+      nil
+    end
+  end
+end
+

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -38,6 +38,10 @@ describe :App do
                 })
   end
 
+  after(:each) do
+    $cache.clear
+  end
+
   describe 'GET /usrname' do
     it do
       get '/username'

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -1,0 +1,47 @@
+
+require 'timecop'
+require 'cache'
+
+describe Cache::TTLCache do
+
+  def assert_fetching_cache(key)
+    called = false
+    result = @cache.with_cache(key) { called = true }
+    expect(called).to be true
+    expect(result).to be true
+  end
+
+  before(:each) do
+    @cache = Cache::TTLCache.new
+  end
+
+  context 'cache is empty' do
+    it 'call block to fetch' do
+      assert_fetching_cache('key')
+    end
+  end
+
+  context 'cache has an entry' do
+    before(:each) do
+      @now = Time.now
+      Timecop.freeze(@now)
+      @cache.with_cache('key') { 'value' }
+    end
+
+    it 'cache returns the value without calling block' do
+      result = @cache.with_cache('key') { raise 'must not called' }
+      expect(result).to be == 'value'
+    end
+
+    context 'at expired time' do
+      before(:each) do
+        Timecop.travel(@now + 1000000) # expire the entry
+      end
+
+      it 'call block to fetch' do
+        assert_fetching_cache('key')
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
## Issue
As wider usage of jfroxy, we notice that error responses from Artifactory sometimes occur.
Because the response includes `blocked due to recurrent login failures, please try again in 1 seconds`, I suppose too many access cause the issue.

## Solution
Add cache for all `/api/*` requests. Please review this PR.
🙏 